### PR TITLE
Implement the Ok monad to work with Yojson

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,7 @@ SRCS+=			lemonade_Continuation.ml
 SRCS+=			lemonade_Lazy.ml
 SRCS+=			lemonade_List.ml
 SRCS+=			lemonade_Maybe.ml
+SRCS+=			lemonade_Ok.ml
 SRCS+=			lemonade_Reader.ml
 SRCS+=			lemonade_Retry.ml
 SRCS+=			lemonade_State.ml

--- a/src/lemonade_Ok.ml
+++ b/src/lemonade_Ok.ml
@@ -1,0 +1,73 @@
+(* Lemonade_Ok -- A variant of the success monad
+
+   Lemonade (https://github.com/michipili/lemonade)
+   This file is part of Lemonade
+
+   Copyright © 2013–2015 Michael Grünewald
+
+   This file must be used under the terms of the CeCILL-B.
+   This source file is licensed as described in the file COPYING, which
+   you should have received as part of this distribution. The terms
+   are also available at
+   http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt *)
+open Printf
+
+module Basis : sig
+  type 'a t = [ `Ok of 'a | `Error of string ]
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
+  val return : 'a -> 'a t
+end = struct
+  type 'a t = [ `Ok of 'a | `Error of string ]
+
+  let bind m (f : 'a -> 'b t) =
+    match m with
+    |`Ok(x) -> f x
+    |`Error(_) as error -> error
+
+  let return x =
+    `Ok(x)
+end
+
+module Methods =
+  Mixture_Monad.Make(Basis)
+
+include Basis
+include Methods
+
+let run = function
+  |`Ok(whatever) -> whatever
+  |`Error(mesg) -> ksprintf failwith "Error: %s" mesg
+
+let error mesg =
+  `Error(mesg)
+
+let errorf fmt =
+  ksprintf (fun mesg -> `Error mesg) fmt
+
+let pp_print f pp = function
+  | `Ok(x) -> Format.fprintf pp "`Ok(%a)" f x
+  | `Error(mesg) -> Format.fprintf pp "`Error(%S)" mesg
+
+module T(M:Mixture_Monad.S) =
+struct
+  module Germ : sig
+    type 'a t = [ `Ok of 'a | `Error of string ] M.t
+    val bind : 'a t -> ('a -> 'b t) -> 'b t
+    val return : 'a -> 'a t
+  end = struct
+
+    type 'a t =
+      'a Basis.t M.t
+
+    let bind m f =
+      M.bind m
+        (function
+          | `Ok(x) -> f x
+          | `Error(err) -> M.return (`Error(err)))
+
+    let return x =
+      M.return(`Ok(x))
+  end
+
+  include Mixture_Monad.Transformer.Make(Basis)(M)(Germ)
+end

--- a/src/lemonade_Ok.mli
+++ b/src/lemonade_Ok.mli
@@ -1,0 +1,48 @@
+(* Lemonade_Ok -- A variant of the success monad
+
+   Lemonade (https://github.com/michipili/lemonade)
+   This file is part of Lemonade
+
+   Copyright © 2013–2015 Michael Grünewald
+
+   This file must be used under the terms of the CeCILL-B.
+   This source file is licensed as described in the file COPYING, which
+   you should have received as part of this distribution. The terms
+   are also available at
+   http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt *)
+
+(** A widely spread variant of the success monad.
+
+It is mainly useful when working with Yojson. *)
+
+type (+'a) t =
+  [ `Error of string | `Ok of 'a ]
+(** The type of monads computing a value of type ['a] or failing with
+    an error message. *)
+
+include Lemonade_Type.S
+    with type 'a t := 'a t
+
+val error : string -> 'a t
+(** A computation failed with the given error message. *)
+
+val errorf : ('a, unit, string, 'b t) format4 -> 'a
+(** A computation failed with the given error message, formatted by sprintf. *)
+
+val run : 'a t -> 'a
+(** [run m] return the value computed by [m] if [m] succeeded or throw
+    a [Failure] exception with the given message otherwise. *)
+
+val pp_print : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+(** A generic printer for monadic values. *)
+
+
+
+(** The maybe monad transformer. *)
+module T(M:Lemonade_Type.S) :
+sig
+  include Lemonade_Type.S
+    with type 'a t = [ `Error of string | `Ok of 'a ] M.t
+
+  val lift : 'a M.t -> 'a t
+end


### PR DESCRIPTION
This is a variant of the classic Success monad implemented using polymorphic variants `\`Ok`and``Error`. This monad should ease the work with yojson.

@mjambon Maybe you can skim over this, if you see any function that could be added there, just le me know!  The list of standard monadic functions is defined by [Lemonade_Type.S](https://michipili.github.io/lemonade/v0.3.0/Lemonade_Type.S.html).
